### PR TITLE
Update Config.Example 

### DIFF
--- a/config.json.EXAMPLE
+++ b/config.json.EXAMPLE
@@ -77,7 +77,7 @@
             "active": true
         },
         "DAI-USDT": {
-            "priceFeedPrimary": "cryptowatch:63349",
+            "priceFeedPrimary": "cryptowatch:61475",
             "priceFeedSecondary": null,
             "slippageRate": 1e-9,
             "maxSize": 100000,


### PR DESCRIPTION
The id in the config.example is not active anymore. The mm will ignore this pair. Updated from binace to kraken - number 1 for DAI/USDT (volume).

From: {"id":63349,"exchange":"binance","pair":"daiusdt","active":false,"route":"https://api.cryptowat.ch/markets/binance/daiusdt"}
To: {"id":61475,"exchange":"kraken","pair":"daiusdt","active":true,"route":"https://api.cryptowat.ch/markets/kraken/daiusdt"}