### PR TITLE
Fix wrong case of uniswapv3 key in setup

### DIFF
--- a/marketmaker.js
+++ b/marketmaker.js
@@ -639,7 +639,7 @@ async function uniswapV3Setup(uniswapV3Address) {
               tokenProvier1.decimals()
             ]);
   
-            const key = 'uniswapV3:' + address;
+            const key = 'uniswapv3:' + address;
             const decimalsRatio = (10**decimals0 / 10**decimals1);  
             UNISWAP_V3_PROVIDERS[key] = [provider, decimalsRatio];
 


### PR DESCRIPTION
The casing of the word "uniswapV3" in the setup doesn't match the casing when trying to access the data later "uniswapv3" resulting in "Primary Pricefeed not available" errors  when trying to use this pricefeed option.

This commit should fix that.