### PR TITLE
Add uniswapV3 to the price feed list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Orders coming in below the `minSpread` from the price feed will not be filled. T
 
 #### Price Feed
 
-There are 3 modes available with a 4th on the way.
+There are 4 modes available with a 5th on the way.
 
 * `cryptowatch`: Follows an external price oracle.
 * `chainlink` : Follows an external price oracle. Chainlink is WEB3 and might be slower then cryptowatch.
 * `constant`: Sets an fixed price and market makes around that price. Can be combined with single-sided liquidity to simulate limit orders.
+* `uniswapV3`: Reads prices on-chain from a specified uniswapV3 pool
 * `independent`: Under development. The price is set independent of a price feed.
 
 **Warning:** Make sure your price feed is close to the price you see on zigzag. **Otherwise, your mm can lose money!**


### PR DESCRIPTION
The uniswap option was not mentioned in the introduction of the `Price Feed` section, which is somewhat confusing.
This commit fixes that.